### PR TITLE
lenovo miix 630 works with 221101-01 

### DIFF
--- a/systems/snapdragon_835/readme.md
+++ b/systems/snapdragon_835/readme.md
@@ -8,11 +8,11 @@
 ## tested systems - working
 
 - asus novago tp370ql
+- lenovo miix 630
 
 ## untested systems
 
 - hp envy x2
-- lenovo miix 630
 - maybe rhere are more laptops with a snapdragon 835
 
 ## kernel build notes


### PR DESCRIPTION
it works fine, first boot it just hanged but restarted then it worked fine, obv had to connect external keyboard and mouse because the internals doesn't
if there's anything you want me to test let me know
![image](https://user-images.githubusercontent.com/82727556/213482003-7c92f7ba-efcf-48a6-aed2-c1b7bb9f1d50.png)
