### PR TITLE
Add ucm & libinput config for trogdor-coachz 

### DIFF
--- a/systems/chromebook_trogdor/extra-files/usr/share/alsa/ucm2/Qualcomm/sc7180/adau7002-max98357a/HiFi.conf
+++ b/systems/chromebook_trogdor/extra-files/usr/share/alsa/ucm2/Qualcomm/sc7180/adau7002-max98357a/HiFi.conf
@@ -1,0 +1,25 @@
+SectionDevice."Speaker".0 {
+	Comment "Speakers"
+	Value {
+		PlaybackPCM "hw:${CardId},1"
+		PlaybackChannels 2
+		PlaybackRate 48000
+		PlaybackPriority 100
+	}
+}
+
+SectionDevice."Mic".0 {
+	Comment "Internal Mic"
+	Value {
+		CapturePCM "hw:${CardId},0"
+		CapturePriority 100
+	}
+}
+
+#SectionDevice."HDMI".0 {
+#	Comment "HDMI"
+#	Value {
+#		PlaybackPCM "hw:${CardId},2"
+#		JackControl "HDMI Jack"
+#	}
+#}

--- a/systems/chromebook_trogdor/extra-files/usr/share/alsa/ucm2/Qualcomm/sc7180/adau7002-max98357a/sc7180-adau7002-max98357a-1mic.conf
+++ b/systems/chromebook_trogdor/extra-files/usr/share/alsa/ucm2/Qualcomm/sc7180/adau7002-max98357a/sc7180-adau7002-max98357a-1mic.conf
@@ -1,0 +1,10 @@
+Comment "SC7180 ADAU7002 MAX98357A single microphone sound card"
+Syntax 4
+
+SectionUseCase."HiFi" {
+	File "/Qualcomm/sc7180/adau7002-max98357a/HiFi.conf"
+	Comment "Default"
+}
+
+Include.card-init.File "/lib/card-init.conf"
+Include.ctl-remap.File "/lib/ctl-remap.conf"

--- a/systems/chromebook_trogdor/extra-files/usr/share/libinput/90-velvet-coachz.quirks
+++ b/systems/chromebook_trogdor/extra-files/usr/share/libinput/90-velvet-coachz.quirks
@@ -1,0 +1,7 @@
+[HP Chromebook X2 11"]
+MatchUdevType=touchpad
+MatchName=Google Inc. Hammer
+MatchDeviceTree=*coachz*
+ModelChromebook=1
+AttrPressureRange=25:10
+AttrPalmPressureThreshold=180


### PR DESCRIPTION
As discussed in #44, this will add the ucm and libinput quirks to extra-files for trogdor.

- This mostly improves the touchpad situation on Wayland sessions, which should be using the libinput driver by default. On xorg synaptics is taking precedence by default and it seemed to be fine for me.
- Note that the SC7180 configuration in chromebook-trogdor/extra-files is only required for systems older than bookworm, as bookworm's alsa-ucm-conf already has sc7180-rt5682-max98357a
- UCM configuration is added to not conflict with [upstream alsa-lib tree](https://github.com/alsa-project/alsa-ucm-conf/tree/master/ucm2/Qualcomm/sc7180/rt5682-max98357a) but I have not enabled it in conf.d as [this commit](https://github.com/hexdump0815/imagebuilder/commit/f3609e2706353e11789df7e903436e7f9a94065e) will cause a conflict with [upstream](https://github.com/alsa-project/alsa-ucm-conf/tree/master/ucm2/conf.d/SC7180). 

