### PR TITLE
Fix missing links for eMMC installation

### DIFF
--- a/doc/chromebooks/preparing-chromebook.md
+++ b/doc/chromebooks/preparing-chromebook.md
@@ -160,14 +160,14 @@ or
 
 # What now?
 
-well now that you've  managed to boot the system you might want to install it directly onto the device especially if you used usb (usb for reasons has way slower read/write speed than sd card or chromebooks internall memory)
+Well now that you've  managed to boot the system you might want to install it directly onto the device especially if you used usb (usb for reasons has way slower read/write speed than sd card or chromebooks internall memory).
 
-but before doing it, we recommend you to [set gbb flags](./setting_gbb_flags.md) on your device so when battery runs dry you won't lose access to your system
+But before doing it, we recommend you to [set gbb flags](./setting_gbb_flags.md) on your device so when battery runs dry you won't lose access to your system
 
-there are a few ways you could install system
+There are a few ways you could install to system storage (eMMC/SSD)
 
-- [regular](./basic-installation.md) - the simplest one, system installed on your device will **not** be encrypted (except browser passowrds, encrypted drives passwords and everything else stored in user database as it is encrypted independently)
-- [encrypted](./luks-installation.md) - your entire system will be encrypted, you will be forced to type password everytime you boot your device (not recommended for tablets since there is no on screen keyboard)
-- [dualboot](./dualboot-instalation.md) - the system will be installed next to chromeos (in theory it can also be done agains any other linux distro or woa but why?). no encryption unless you fuse this guide with encrypted one.
+- [regular](./basic-installation.md) - The simplest one. The system installed on your device will **not** be encrypted (except browser passowrds, encrypted drives passwords and everything else stored in user database as it is encrypted independently)
+- [encrypted](./luks-installation.md) - Your entire system will be encrypted and you will be forced to type password everytime you boot your device (not recommended for tablets since there is no on screen keyboard)
+- [dualboot](./dualboot-instalation.md) - The system will be installed next to chromeos (in theory it can also be done agains any other linux distro or woa but why?). no encryption unless you fuse this guide with encrypted one.
 
 

--- a/doc/first-steps.md
+++ b/doc/first-steps.md
@@ -52,7 +52,7 @@ https://github.com/hexdump0815/imagebuilder/blob/main/doc/firefox-tuning.md
 - sometimes a newer precompiled kernel is available than the one used in the
   last available image. how to install it in such a case is described in
 https://github.com/hexdump0815/imagebuilder/blob/main/doc/installing-a-newer-kernel.md
-- i would like to encourage people to build their own kernels from time to time
+- I would like to encourage people to build their own kernels from time to time
   or if they want to play around with different kernel options. it is not that
 complicated and the procedure to build a new kernel on the system is described
 in
@@ -62,7 +62,7 @@ https://github.com/hexdump0815/imagebuilder/blob/main/doc/building-own-kernels.m
 https://github.com/hexdump0815/imagebuilder/blob/main/doc/test-booting-a-kernel-on-chromebooks.txt
 - for chromebooks a very interesting option is to install linux to the internal
   emmc storage in case chromeos is no longer required. this is described in
-https://github.com/hexdump0815/imagebuilder/blob/main/doc/install-to-emmc-on-arm-chromebooks.md
+https://github.com/hexdump0815/imagebuilder/blob/main/doc/chromebooks/basic-installation.md. If you want to perform an encrypted installation, check out https://github.com/hexdump0815/imagebuilder/blob/main/doc/chromebooks/luks-installation.md.
 
 another good source of information are the already existing github issues of
 this repository as quite a few topics and problems were discussed there


### PR DESCRIPTION
The links were not updated in first-steps.md, and I mistakenly assumed the tutorial has been deleted (#245).

Fixes #245