### PR TITLE
multiple: workaround for chrome/angle/freedreno bug via mesa drirc

### DIFF
--- a/systems/chromebook_trogdor/extra-files/etc/environment.d/90-freedreno-angle-hack.conf
+++ b/systems/chromebook_trogdor/extra-files/etc/environment.d/90-freedreno-angle-hack.conf
@@ -1,0 +1,11 @@
+# the angle framework, which is used by chrome and chromium and also the
+# electron framework has a bug that it does not work properly with the
+# freedreno gpu driver used on many snapdragon socs and as a result the
+# freedreno driver should hide its name to not trigger that bug - see:
+# https://issues.angleproject.org/issues/431097618
+#
+# currently another workaround is implemented via
+# /usr/share/drirc.d/90-freedreno-angle-hack.conf for a list of applications
+# explicitely - in case to add the workaround globally please uncomment the
+# following line
+#force_gl_vendor=angleisbroken

--- a/systems/chromebook_trogdor/extra-files/usr/share/drirc.d/90-freedreno-angle-hack.conf
+++ b/systems/chromebook_trogdor/extra-files/usr/share/drirc.d/90-freedreno-angle-hack.conf
@@ -1,0 +1,88 @@
+<?xml version="1.0" standalone="yes"?>
+<!--
+
+============================================
+Application bugs worked around in this file:
+============================================
+
+-->
+
+<!DOCTYPE driconf [
+   <!ELEMENT driconf      (device+)>
+   <!ELEMENT device       (application | engine)+>
+   <!ATTLIST device       driver CDATA #IMPLIED
+                          device CDATA #IMPLIED>
+   <!ELEMENT application  (option+)>
+   <!ATTLIST application  name CDATA #REQUIRED
+                          executable CDATA #IMPLIED
+                          executable_regexp CDATA #IMPLIED
+                          sha1 CDATA #IMPLIED
+                          application_name_match CDATA #IMPLIED
+                          application_versions CDATA #IMPLIED>
+   <!ELEMENT engine       (option+)>
+
+   <!-- engine_name_match: A regexp matching the engine name -->
+   <!-- engine_versions: A version in range format
+             (version 1 to 4 : "1:4") -->
+
+   <!ATTLIST engine       engine_name_match CDATA #REQUIRED
+                          engine_versions CDATA #IMPLIED>
+
+   <!ELEMENT option       EMPTY>
+   <!ATTLIST option       name CDATA #REQUIRED
+                          value CDATA #REQUIRED>
+]>
+
+<driconf>
+    <device driver="msm">
+        <!--
+            ANGLE is catastrophically broken, see:
+
+               https://issues.angleproject.org/u/1/issues/431097618
+
+            This broken codepath is exposed when skia detects vendor
+            freedreno (as well as closed mali/img/adreno drivers.. maybe
+            the issue will actually get fixed when a new enough skia+
+            ANGLE hits the closed drivers on android).
+
+            Workaround the issue by spoofing the vendor string so
+            skia doesn't pick the broken ANGLE codepath.  Other
+            electron apps will have the same problem, and should be
+            listed here as well.
+
+            This file is based on:
+            https://oftc.catirclogs.org/aarch64-laptops/2025-09-29#34670310
+
+	    Please also have a look at
+	    /etc/environment.d/90-freedreno-angle-hack.conf
+	    for an alternative workaround.
+         -->
+        <application name="Chromium" executable="chromium">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="Chromium" executable="chromium-browser">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="Chromium" executable="chrome">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="VS Code" executable="code">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="VS Codium" executable="codium">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="element-desktop" executable="element-desktop">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="signal" executable="signal">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="vivaldi-bin" executable="vivaldi-bin">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="code" executable="vivaldi-bin">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+    </device>
+</driconf>

--- a/systems/phone_samsung_a72q/extra-files/etc/environment.d/90-freedreno-angle-hack.conf
+++ b/systems/phone_samsung_a72q/extra-files/etc/environment.d/90-freedreno-angle-hack.conf
@@ -1,0 +1,11 @@
+# the angle framework, which is used by chrome and chromium and also the
+# electron framework has a bug that it does not work properly with the
+# freedreno gpu driver used on many snapdragon socs and as a result the
+# freedreno driver should hide its name to not trigger that bug - see:
+# https://issues.angleproject.org/issues/431097618
+#
+# currently another workaround is implemented via
+# /usr/share/drirc.d/90-freedreno-angle-hack.conf for a list of applications
+# explicitely - in case to add the workaround globally please uncomment the
+# following line
+#force_gl_vendor=angleisbroken

--- a/systems/phone_samsung_a72q/extra-files/usr/share/drirc.d/90-freedreno-angle-hack.conf
+++ b/systems/phone_samsung_a72q/extra-files/usr/share/drirc.d/90-freedreno-angle-hack.conf
@@ -1,0 +1,88 @@
+<?xml version="1.0" standalone="yes"?>
+<!--
+
+============================================
+Application bugs worked around in this file:
+============================================
+
+-->
+
+<!DOCTYPE driconf [
+   <!ELEMENT driconf      (device+)>
+   <!ELEMENT device       (application | engine)+>
+   <!ATTLIST device       driver CDATA #IMPLIED
+                          device CDATA #IMPLIED>
+   <!ELEMENT application  (option+)>
+   <!ATTLIST application  name CDATA #REQUIRED
+                          executable CDATA #IMPLIED
+                          executable_regexp CDATA #IMPLIED
+                          sha1 CDATA #IMPLIED
+                          application_name_match CDATA #IMPLIED
+                          application_versions CDATA #IMPLIED>
+   <!ELEMENT engine       (option+)>
+
+   <!-- engine_name_match: A regexp matching the engine name -->
+   <!-- engine_versions: A version in range format
+             (version 1 to 4 : "1:4") -->
+
+   <!ATTLIST engine       engine_name_match CDATA #REQUIRED
+                          engine_versions CDATA #IMPLIED>
+
+   <!ELEMENT option       EMPTY>
+   <!ATTLIST option       name CDATA #REQUIRED
+                          value CDATA #REQUIRED>
+]>
+
+<driconf>
+    <device driver="msm">
+        <!--
+            ANGLE is catastrophically broken, see:
+
+               https://issues.angleproject.org/u/1/issues/431097618
+
+            This broken codepath is exposed when skia detects vendor
+            freedreno (as well as closed mali/img/adreno drivers.. maybe
+            the issue will actually get fixed when a new enough skia+
+            ANGLE hits the closed drivers on android).
+
+            Workaround the issue by spoofing the vendor string so
+            skia doesn't pick the broken ANGLE codepath.  Other
+            electron apps will have the same problem, and should be
+            listed here as well.
+
+            This file is based on:
+            https://oftc.catirclogs.org/aarch64-laptops/2025-09-29#34670310
+
+	    Please also have a look at
+	    /etc/environment.d/90-freedreno-angle-hack.conf
+	    for an alternative workaround.
+         -->
+        <application name="Chromium" executable="chromium">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="Chromium" executable="chromium-browser">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="Chromium" executable="chrome">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="VS Code" executable="code">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="VS Codium" executable="codium">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="element-desktop" executable="element-desktop">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="signal" executable="signal">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="vivaldi-bin" executable="vivaldi-bin">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="code" executable="vivaldi-bin">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+    </device>
+</driconf>

--- a/systems/snapdragon_7c_woa/extra-files/etc/environment.d/90-freedreno-angle-hack.conf
+++ b/systems/snapdragon_7c_woa/extra-files/etc/environment.d/90-freedreno-angle-hack.conf
@@ -1,0 +1,11 @@
+# the angle framework, which is used by chrome and chromium and also the
+# electron framework has a bug that it does not work properly with the
+# freedreno gpu driver used on many snapdragon socs and as a result the
+# freedreno driver should hide its name to not trigger that bug - see:
+# https://issues.angleproject.org/issues/431097618
+#
+# currently another workaround is implemented via
+# /usr/share/drirc.d/90-freedreno-angle-hack.conf for a list of applications
+# explicitely - in case to add the workaround globally please uncomment the
+# following line
+#force_gl_vendor=angleisbroken

--- a/systems/snapdragon_7c_woa/extra-files/usr/share/drirc.d/90-freedreno-angle-hack.conf
+++ b/systems/snapdragon_7c_woa/extra-files/usr/share/drirc.d/90-freedreno-angle-hack.conf
@@ -1,0 +1,88 @@
+<?xml version="1.0" standalone="yes"?>
+<!--
+
+============================================
+Application bugs worked around in this file:
+============================================
+
+-->
+
+<!DOCTYPE driconf [
+   <!ELEMENT driconf      (device+)>
+   <!ELEMENT device       (application | engine)+>
+   <!ATTLIST device       driver CDATA #IMPLIED
+                          device CDATA #IMPLIED>
+   <!ELEMENT application  (option+)>
+   <!ATTLIST application  name CDATA #REQUIRED
+                          executable CDATA #IMPLIED
+                          executable_regexp CDATA #IMPLIED
+                          sha1 CDATA #IMPLIED
+                          application_name_match CDATA #IMPLIED
+                          application_versions CDATA #IMPLIED>
+   <!ELEMENT engine       (option+)>
+
+   <!-- engine_name_match: A regexp matching the engine name -->
+   <!-- engine_versions: A version in range format
+             (version 1 to 4 : "1:4") -->
+
+   <!ATTLIST engine       engine_name_match CDATA #REQUIRED
+                          engine_versions CDATA #IMPLIED>
+
+   <!ELEMENT option       EMPTY>
+   <!ATTLIST option       name CDATA #REQUIRED
+                          value CDATA #REQUIRED>
+]>
+
+<driconf>
+    <device driver="msm">
+        <!--
+            ANGLE is catastrophically broken, see:
+
+               https://issues.angleproject.org/u/1/issues/431097618
+
+            This broken codepath is exposed when skia detects vendor
+            freedreno (as well as closed mali/img/adreno drivers.. maybe
+            the issue will actually get fixed when a new enough skia+
+            ANGLE hits the closed drivers on android).
+
+            Workaround the issue by spoofing the vendor string so
+            skia doesn't pick the broken ANGLE codepath.  Other
+            electron apps will have the same problem, and should be
+            listed here as well.
+
+            This file is based on:
+            https://oftc.catirclogs.org/aarch64-laptops/2025-09-29#34670310
+
+	    Please also have a look at
+	    /etc/environment.d/90-freedreno-angle-hack.conf
+	    for an alternative workaround.
+         -->
+        <application name="Chromium" executable="chromium">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="Chromium" executable="chromium-browser">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="Chromium" executable="chrome">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="VS Code" executable="code">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="VS Codium" executable="codium">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="element-desktop" executable="element-desktop">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="signal" executable="signal">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="vivaldi-bin" executable="vivaldi-bin">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="code" executable="vivaldi-bin">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+    </device>
+</driconf>

--- a/systems/snapdragon_835/extra-files/etc/environment.d/90-freedreno-angle-hack.conf
+++ b/systems/snapdragon_835/extra-files/etc/environment.d/90-freedreno-angle-hack.conf
@@ -1,0 +1,11 @@
+# the angle framework, which is used by chrome and chromium and also the
+# electron framework has a bug that it does not work properly with the
+# freedreno gpu driver used on many snapdragon socs and as a result the
+# freedreno driver should hide its name to not trigger that bug - see:
+# https://issues.angleproject.org/issues/431097618
+#
+# currently another workaround is implemented via
+# /usr/share/drirc.d/90-freedreno-angle-hack.conf for a list of applications
+# explicitely - in case to add the workaround globally please uncomment the
+# following line
+#force_gl_vendor=angleisbroken

--- a/systems/snapdragon_835/extra-files/usr/share/drirc.d/90-freedreno-angle-hack.conf
+++ b/systems/snapdragon_835/extra-files/usr/share/drirc.d/90-freedreno-angle-hack.conf
@@ -1,0 +1,88 @@
+<?xml version="1.0" standalone="yes"?>
+<!--
+
+============================================
+Application bugs worked around in this file:
+============================================
+
+-->
+
+<!DOCTYPE driconf [
+   <!ELEMENT driconf      (device+)>
+   <!ELEMENT device       (application | engine)+>
+   <!ATTLIST device       driver CDATA #IMPLIED
+                          device CDATA #IMPLIED>
+   <!ELEMENT application  (option+)>
+   <!ATTLIST application  name CDATA #REQUIRED
+                          executable CDATA #IMPLIED
+                          executable_regexp CDATA #IMPLIED
+                          sha1 CDATA #IMPLIED
+                          application_name_match CDATA #IMPLIED
+                          application_versions CDATA #IMPLIED>
+   <!ELEMENT engine       (option+)>
+
+   <!-- engine_name_match: A regexp matching the engine name -->
+   <!-- engine_versions: A version in range format
+             (version 1 to 4 : "1:4") -->
+
+   <!ATTLIST engine       engine_name_match CDATA #REQUIRED
+                          engine_versions CDATA #IMPLIED>
+
+   <!ELEMENT option       EMPTY>
+   <!ATTLIST option       name CDATA #REQUIRED
+                          value CDATA #REQUIRED>
+]>
+
+<driconf>
+    <device driver="msm">
+        <!--
+            ANGLE is catastrophically broken, see:
+
+               https://issues.angleproject.org/u/1/issues/431097618
+
+            This broken codepath is exposed when skia detects vendor
+            freedreno (as well as closed mali/img/adreno drivers.. maybe
+            the issue will actually get fixed when a new enough skia+
+            ANGLE hits the closed drivers on android).
+
+            Workaround the issue by spoofing the vendor string so
+            skia doesn't pick the broken ANGLE codepath.  Other
+            electron apps will have the same problem, and should be
+            listed here as well.
+
+            This file is based on:
+            https://oftc.catirclogs.org/aarch64-laptops/2025-09-29#34670310
+
+	    Please also have a look at
+	    /etc/environment.d/90-freedreno-angle-hack.conf
+	    for an alternative workaround.
+         -->
+        <application name="Chromium" executable="chromium">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="Chromium" executable="chromium-browser">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="Chromium" executable="chrome">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="VS Code" executable="code">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="VS Codium" executable="codium">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="element-desktop" executable="element-desktop">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="signal" executable="signal">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="vivaldi-bin" executable="vivaldi-bin">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="code" executable="vivaldi-bin">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+    </device>
+</driconf>

--- a/systems/tablet_samsung_gt510/extra-files/etc/environment.d/90-freedreno-angle-hack.conf
+++ b/systems/tablet_samsung_gt510/extra-files/etc/environment.d/90-freedreno-angle-hack.conf
@@ -1,0 +1,11 @@
+# the angle framework, which is used by chrome and chromium and also the
+# electron framework has a bug that it does not work properly with the
+# freedreno gpu driver used on many snapdragon socs and as a result the
+# freedreno driver should hide its name to not trigger that bug - see:
+# https://issues.angleproject.org/issues/431097618
+#
+# currently another workaround is implemented via
+# /usr/share/drirc.d/90-freedreno-angle-hack.conf for a list of applications
+# explicitely - in case to add the workaround globally please uncomment the
+# following line
+#force_gl_vendor=angleisbroken

--- a/systems/tablet_samsung_gt510/extra-files/usr/share/drirc.d/90-freedreno-angle-hack.conf
+++ b/systems/tablet_samsung_gt510/extra-files/usr/share/drirc.d/90-freedreno-angle-hack.conf
@@ -1,0 +1,88 @@
+<?xml version="1.0" standalone="yes"?>
+<!--
+
+============================================
+Application bugs worked around in this file:
+============================================
+
+-->
+
+<!DOCTYPE driconf [
+   <!ELEMENT driconf      (device+)>
+   <!ELEMENT device       (application | engine)+>
+   <!ATTLIST device       driver CDATA #IMPLIED
+                          device CDATA #IMPLIED>
+   <!ELEMENT application  (option+)>
+   <!ATTLIST application  name CDATA #REQUIRED
+                          executable CDATA #IMPLIED
+                          executable_regexp CDATA #IMPLIED
+                          sha1 CDATA #IMPLIED
+                          application_name_match CDATA #IMPLIED
+                          application_versions CDATA #IMPLIED>
+   <!ELEMENT engine       (option+)>
+
+   <!-- engine_name_match: A regexp matching the engine name -->
+   <!-- engine_versions: A version in range format
+             (version 1 to 4 : "1:4") -->
+
+   <!ATTLIST engine       engine_name_match CDATA #REQUIRED
+                          engine_versions CDATA #IMPLIED>
+
+   <!ELEMENT option       EMPTY>
+   <!ATTLIST option       name CDATA #REQUIRED
+                          value CDATA #REQUIRED>
+]>
+
+<driconf>
+    <device driver="msm">
+        <!--
+            ANGLE is catastrophically broken, see:
+
+               https://issues.angleproject.org/u/1/issues/431097618
+
+            This broken codepath is exposed when skia detects vendor
+            freedreno (as well as closed mali/img/adreno drivers.. maybe
+            the issue will actually get fixed when a new enough skia+
+            ANGLE hits the closed drivers on android).
+
+            Workaround the issue by spoofing the vendor string so
+            skia doesn't pick the broken ANGLE codepath.  Other
+            electron apps will have the same problem, and should be
+            listed here as well.
+
+            This file is based on:
+            https://oftc.catirclogs.org/aarch64-laptops/2025-09-29#34670310
+
+	    Please also have a look at
+	    /etc/environment.d/90-freedreno-angle-hack.conf
+	    for an alternative workaround.
+         -->
+        <application name="Chromium" executable="chromium">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="Chromium" executable="chromium-browser">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="Chromium" executable="chrome">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="VS Code" executable="code">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="VS Codium" executable="codium">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="element-desktop" executable="element-desktop">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="signal" executable="signal">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="vivaldi-bin" executable="vivaldi-bin">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+        <application name="code" executable="vivaldi-bin">
+            <option name="force_gl_vendor" value="angleisbroken"/>
+        </application>
+    </device>
+</driconf>


### PR DESCRIPTION
angle which is used by chrome and as a result by all electron apps has a bug so that it does not work well together with the freedreno gpu driver used for most snapdragon socs - for more details see: https://issues.angleproject.org/issues/431097618

lets add it to all snapdragon systems - more apps using the electron framework will have to / can be added to that config file if needed ...