### PR TITLE
asurada,cherry,corsola,kukui: no more panfrost hacks via env

### DIFF
--- a/systems/chromebook_asurada/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
+++ b/systems/chromebook_asurada/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
@@ -1,5 +1,0 @@
-# disable some opengl extensions for gtk rendering as there
-# will be problems with the panfrost gpu drivers otherwise
-# see: https://github.com/velvet-os/imagebuilder/discussions/284#discussioncomment-11965708
-# and: https://gitlab.postmarketos.org/postmarketOS/pmaports/-/issues/3297
-GDK_GL_DISABLE=base-instance

--- a/systems/chromebook_asurada/extra-files/etc/environment.d/99-noafbc.conf
+++ b/systems/chromebook_asurada/extra-files/etc/environment.d/99-noafbc.conf
@@ -1,3 +1,0 @@
-# disable afbc in mesa until it is fixed from the kernel side
-# see: https://github.com/velvet-os/imagebuilder/issues/314
-PAN_MESA_DEBUG=noafbc

--- a/systems/chromebook_cherry/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
+++ b/systems/chromebook_cherry/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
@@ -1,5 +1,0 @@
-# disable some opengl extensions for gtk rendering as there
-# will be problems with the panfrost gpu drivers otherwise
-# see: https://github.com/velvet-os/imagebuilder/discussions/284#discussioncomment-11965708
-# and: https://gitlab.postmarketos.org/postmarketOS/pmaports/-/issues/3297
-GDK_GL_DISABLE=base-instance

--- a/systems/chromebook_cherry/extra-files/etc/environment.d/99-noafbc.conf
+++ b/systems/chromebook_cherry/extra-files/etc/environment.d/99-noafbc.conf
@@ -1,3 +1,0 @@
-# disable afbc in mesa until it is fixed from the kernel side
-# see: https://github.com/velvet-os/imagebuilder/issues/314
-PAN_MESA_DEBUG=noafbc

--- a/systems/chromebook_corsola/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
+++ b/systems/chromebook_corsola/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
@@ -1,5 +1,0 @@
-# disable some opengl extensions for gtk rendering as there
-# will be problems with the panfrost gpu drivers otherwise
-# see: https://github.com/velvet-os/imagebuilder/discussions/284#discussioncomment-11965708
-# and: https://gitlab.postmarketos.org/postmarketOS/pmaports/-/issues/3297
-GDK_GL_DISABLE=base-instance

--- a/systems/chromebook_corsola/extra-files/etc/environment.d/99-noafbc.conf
+++ b/systems/chromebook_corsola/extra-files/etc/environment.d/99-noafbc.conf
@@ -1,3 +1,0 @@
-# disable afbc in mesa until it is fixed from the kernel side
-# see: https://github.com/velvet-os/imagebuilder/issues/314
-PAN_MESA_DEBUG=noafbc

--- a/systems/chromebook_kukui/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
+++ b/systems/chromebook_kukui/extra-files/etc/environment.d/98-gtk-disable-some-opengl.conf
@@ -1,5 +1,0 @@
-# disable some opengl extensions for gtk rendering as there
-# will be problems with the panfrost gpu drivers otherwise
-# see: https://github.com/velvet-os/imagebuilder/discussions/284#discussioncomment-11965708
-# and: https://gitlab.postmarketos.org/postmarketOS/pmaports/-/issues/3297
-GDK_GL_DISABLE=base-instance

--- a/systems/chromebook_kukui/extra-files/etc/environment.d/99-noafbc.conf
+++ b/systems/chromebook_kukui/extra-files/etc/environment.d/99-noafbc.conf
@@ -1,3 +1,0 @@
-# disable afbc in mesa until it is fixed from the kernel side
-# see: https://github.com/velvet-os/imagebuilder/issues/314
-PAN_MESA_DEBUG=noafbc


### PR DESCRIPTION
panfrost on mediatek has problems with afbc (arm frame buffer compression) so that it has to be disabled - so far we did this by setting some env variable for the affected systems, but we will disable it in the kernel for now, so that the env hack will no longer required

this mainly is for the 99-noafbc.conf hack, but while at it lets try to see if the other 98-gtk-disable-some-opengl.conf hack can be reomved as well

for reference - this is the kernel change doing the afbc disabling now: https://github.com/hexdump0815/linux-mainline-mediatek-mt81xx-kernel/pull/22