### PR TITLE
multiple: link 2025 autumn release images and testimages

### DIFF
--- a/systems/aarch64_mbr_uefi/readme.md
+++ b/systems/aarch64_mbr_uefi/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (experimental testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/mixed-testimages-01 (experimental testimage)
 
 ## tested systems - working

--- a/systems/allwinner_h3/readme.md
+++ b/systems/allwinner_h3/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-07 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231126-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/210808-01

--- a/systems/allwinner_h6/readme.md
+++ b/systems/allwinner_h6/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-03 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230930-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230222-01

--- a/systems/allwinner_h616/readme.md
+++ b/systems/allwinner_h616/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-03 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230910-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230222-02

--- a/systems/amlogic_gx/readme.md
+++ b/systems/amlogic_gx/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-03 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230920-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230220-04

--- a/systems/amlogic_m8/readme.md
+++ b/systems/amlogic_m8/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-07 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230910-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230224-03

--- a/systems/atom_x86_with_32bit_uefi/readme.md
+++ b/systems/atom_x86_with_32bit_uefi/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder/releases/tag/251115-03
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-06 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230917-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230224-04

--- a/systems/bpi_f3/readme.md
+++ b/systems/bpi_f3/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder/releases/tag/251115-04
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-04 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/240521-01
 

--- a/systems/chromebook_asurada/readme.md
+++ b/systems/chromebook_asurada/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (experimental testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/mixed-testimages-01 (experimental testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230109-01 (experimental)
 - https://github.com/velvet-os/imagebuilder/releases/tag/220710-01

--- a/systems/chromebook_cherry/readme.md
+++ b/systems/chromebook_cherry/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (experimental testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/mixed-testimages-01 (experimental testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230109-01 (experimental)
 - https://github.com/velvet-os/imagebuilder/releases/tag/220710-01

--- a/systems/chromebook_corsola/readme.md
+++ b/systems/chromebook_corsola/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder/releases/tag/251115-01
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-01 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/240112-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230626-01

--- a/systems/chromebook_gru/readme.md
+++ b/systems/chromebook_gru/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder/releases/tag/251115-01
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-01 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231001-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230220-03

--- a/systems/chromebook_kukui/readme.md
+++ b/systems/chromebook_kukui/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder/releases/tag/251115-01
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-01 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230917-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230218-01

--- a/systems/chromebook_nyan/readme.md
+++ b/systems/chromebook_nyan/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder/releases/tag/251115-02
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-02 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230915-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230218-04

--- a/systems/chromebook_oak/readme.md
+++ b/systems/chromebook_oak/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder/releases/tag/251115-01
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-01 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230920-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230218-02

--- a/systems/chromebook_peach/readme.md
+++ b/systems/chromebook_peach/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder/releases/tag/251115-02
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-02 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230924-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230220-02

--- a/systems/chromebook_snow/readme.md
+++ b/systems/chromebook_snow/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder/releases/tag/251115-02
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-02 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230924-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230220-01

--- a/systems/chromebook_trogdor/readme.md
+++ b/systems/chromebook_trogdor/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder/releases/tag/251115-01
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-01 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230922-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230501-01

--- a/systems/chromebook_veyron/readme.md
+++ b/systems/chromebook_veyron/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder/releases/tag/251115-02
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-02 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231001-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230218-05

--- a/systems/chromebook_x86_mbr/readme.md
+++ b/systems/chromebook_x86_mbr/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder/releases/tag/251115-03
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-06 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231002-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230222-03

--- a/systems/chromebook_x86_uefi/readme.md
+++ b/systems/chromebook_x86_uefi/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder/releases/tag/251115-03
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-06 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231002-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230222-04

--- a/systems/console_rg552/readme.md
+++ b/systems/console_rg552/readme.md
@@ -2,7 +2,7 @@
 
 ## bootable sd card images
 
-- not available now
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (experimental testimage)
 
 ## tested systems - working
 

--- a/systems/console_x55/readme.md
+++ b/systems/console_x55/readme.md
@@ -2,7 +2,7 @@
 
 ## bootable sd card images
 
-- not available now
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (experimental testimage)
 
 ## tested systems - working
 

--- a/systems/odroid_u3/readme.md
+++ b/systems/odroid_u3/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-07 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230915-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230224-05

--- a/systems/orbsmart_s92_beelink_r89/readme.md
+++ b/systems/orbsmart_s92_beelink_r89/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-07 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231002-05
 - https://github.com/velvet-os/imagebuilder/releases/tag/230222-05

--- a/systems/phone_motorola_harpia/readme.md
+++ b/systems/phone_motorola_harpia/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-05 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231111-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/211231-02

--- a/systems/phone_samsung_a72q/readme.md
+++ b/systems/phone_samsung_a72q/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (experimental testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231126-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230929-01
 

--- a/systems/raspberry_pi_4/readme.md
+++ b/systems/raspberry_pi_4/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-03 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231002-03
 - https://github.com/velvet-os/imagebuilder/releases/tag/230224-01

--- a/systems/rockchip_rk33xx/readme.md
+++ b/systems/rockchip_rk33xx/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-03 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/230930-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230220-05

--- a/systems/rockchip_rk356x/readme.md
+++ b/systems/rockchip_rk356x/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-03 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231002-04
 - https://github.com/velvet-os/imagebuilder/releases/tag/230224-02

--- a/systems/snapdragon_7c_woa/readme.md
+++ b/systems/snapdragon_7c_woa/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-08 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/240107-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230308-01

--- a/systems/snapdragon_835/readme.md
+++ b/systems/snapdragon_835/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-08 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/240112-02
 - https://github.com/velvet-os/imagebuilder/releases/tag/230322-01

--- a/systems/starfive_visionfive2/readme.md
+++ b/systems/starfive_visionfive2/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder/releases/tag/251115-04
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-04 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/240519-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/230321-02

--- a/systems/tablet_samsung_gt510/readme.md
+++ b/systems/tablet_samsung_gt510/readme.md
@@ -2,6 +2,7 @@
 
 ## bootable sd card images
 
+- https://github.com/velvet-os/imagebuilder-testimages/releases/tag/autumn-release-2025-testimages (testimage)
 - https://github.com/velvet-os/imagebuilder-testimages/releases/tag/spring-release-2025-testimages-round-05 (testimage)
 - https://github.com/velvet-os/imagebuilder/releases/tag/231111-01
 - https://github.com/velvet-os/imagebuilder/releases/tag/211231-01


### PR DESCRIPTION
link the 2025 autumn release images for the systems we have mostly good test coverage for:
- well supported aarch64 (64 bit arm) chromebooks
- armv7l (32 bit arm) chromebooks
- x86_64 devices
- risc-v sbcs

for the other systems link the 2025 autumn testimages for the ones we have such available, so that they get more test coverage and people start to use those latest available and debian trixie based images instead of older ones ... once we have good test coverage for some of those, new proper releases will be created for them and linked instead of the testimage links