### PR TITLE
updated tested systems in chromebook gru

### DIFF
--- a/systems/chromebook_gru/readme.md
+++ b/systems/chromebook_gru/readme.md
@@ -14,10 +14,7 @@
 
 - asus chromebook flip c101p - bob
 - samsung chromebook plus xe513c24 - kevin
-- acer chromebook tab 10 - scarlet (wip)
-
-## untested systems
-
+- acer chromebook tab 10 - scarlet
 - asus chromebook tablet ct100 - dumo
 
 ## generic mainline linux on arm chromebook notes


### PR DESCRIPTION
Both scarlet and dumo work with velvet-os. Let's remove them from untested devices.